### PR TITLE
fix: padding das sections para scroll correto

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -98,6 +98,10 @@ li{
   width: 220px;
 }
 
+section {
+  padding: 12vh 0;
+}
+
 section > p {
   padding: 0 10rem;
   font-size: 20px;


### PR DESCRIPTION
Era necessário adicionar padding vertical nas sections do tamanho do `nav` (12vh) para que fosse corrigido o problema de sobreposição ao clicar nas opções do `nav`. 

[Assistir demonstração](https://youtu.be/reG-kf8GtGU)