### PR TITLE
feat: responsividade inicial

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -29,11 +29,13 @@ header {
 }
 
 header > section{
+  padding: 4rem;
   height: 100%;
   width: 100%;
   background-color: #1b1a1a69;
   display: grid;
   place-items: center;
+  text-align: center;
 }
 
 h1 {
@@ -143,4 +145,44 @@ section > p {
 
 #sobre p{
   text-indent: px;
+}
+
+@media only screen and (max-width: 600px) {
+  header {
+    height: 50vh;
+  }
+
+  nav {
+    gap: 4rem;
+  }
+
+  h1 {
+    font-size: 60px;
+  }
+
+  section > p {
+    padding: 0 3rem;
+  }
+}
+
+@media only screen and (max-width: 420px) {
+  header {
+    height: 50vh;
+  }
+
+  nav {
+    gap: 2rem;
+  }
+
+  header > section {
+    padding: 0;
+  }
+
+  h1 {
+    font-size: 50px;
+  }
+
+  section > p {
+    padding: 0 3rem;
+  }
 }


### PR DESCRIPTION
Ainda há muito o que melhorar na responsividade. Eis algumas sugestões:

- Na media query para tela de `420px` width, transformar o `nav` em algo como um ícone de hambúrguer para expandir as opções. Exemplo:
![image](https://user-images.githubusercontent.com/31693006/216204787-780ae62d-c35f-43e7-9485-c1604fdad4a1.png)
- Footer não está responsivo ainda
- Talvez o tamanho das fontes dos parágrafos devessem ficar menores
- Que tal esconder parte dos parágrafos longos? Tipo adicionar um botão "Ver mais" e então expandiria o resto do texto


Por fim, [demonstração da PR](https://youtu.be/sQxzsIZxjxk)
 